### PR TITLE
fix(shuffle.cc): fix compile error

### DIFF
--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -20,6 +20,7 @@ limitations under the License.
 #include <unistd.h>
 #include <cstdio>
 #include <iostream>
+#include <algorithm>
 #include <stdexcept>
 
 namespace {


### PR DESCRIPTION
no matching function for call to ‘max(<brace-enclosed initializer list>)’