### PR TITLE
Permit compilation under musl

### DIFF
--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -22,6 +22,7 @@ limitations under the License.
 #include <iostream>
 #include <algorithm>
 #include <stdexcept>
+#include <sys/select.h>
 
 namespace {
 bool set_nonblock(int fd)


### PR DESCRIPTION
When attempting to compile under musl, the compiler warned that FD_SET (and various other fd-related things) were undefined. Adding an explicit include for `sys/select.h` in `shuffle.cc` fixed compilation there (and doesn't appear affect compilation under glibc).