### PR TITLE
Macos: Add IOBluetooth RFCOMM client (bt-connecter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ is.
 bt-connecter -t AA:BB:CC:XX:YY:ZZ 5
 ```
 
+## macOS client
+
+`macos/` contains a native macOS client, `bt-connecter`, built on
+IOBluetooth. It bridges stdin/stdout to an RFCOMM channel and takes the
+same positional arguments as the Linux client. Terminal mode (`-t`) is
+not implemented.
+
+```
+cd macos
+make
+./bt-connecter AA:BB:CC:XX:YY:ZZ 2
+```
+
+Building requires the Xcode command line tools (`swiftc`). The binary
+works as an SSH `ProxyCommand` as in the examples above.
+
+The server side needs no SDP record; the channel is opened directly by
+number. The application running `bt-connecter` (typically the terminal
+emulator) must have Bluetooth permission (System Settings > Privacy &
+Security > Bluetooth); macOS prompts on first use.
+
 ## Portability
 
 Code currently relies on `signalfd()`, so it's Linux-only. Should be
@@ -56,5 +77,8 @@ portable to FreeBSD and MacOSX using `kqueue() with EVFILT_SIGNAL`,
 but I don't have a mac to develop it on.
 
 Alternatively we could switch to libevent.
+
+A native macOS client exists in `macos/` (see above); the notes here
+apply to the C++ tools.
 
 [blog]: https://blog.habets.se/2022/02/SSH-over-Bluetooth-cleanly.html

--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ make
 ./bt-connecter AA:BB:CC:XX:YY:ZZ 2
 ```
 
-Building requires the Xcode command line tools (`swiftc`). The binary
-works as an SSH `ProxyCommand` as in the examples above.
+Building requires the Xcode command line tools (`swiftc`). The build
+does not install the binary, so reference it by absolute path in an SSH
+`ProxyCommand` (otherwise it works as in the examples above).
 
 The server side needs no SDP record; the channel is opened directly by
 number. The application running `bt-connecter` (typically the terminal

--- a/macos/GNUmakefile
+++ b/macos/GNUmakefile
@@ -1,0 +1,11 @@
+BINARY = bt-connecter
+SOURCES = bt-connecter.swift
+SWIFTFLAGS = -framework IOBluetooth -framework Foundation
+
+$(BINARY): $(SOURCES)
+	swiftc $(SOURCES) $(SWIFTFLAGS) -o $(BINARY)
+
+clean:
+	rm -f $(BINARY)
+
+.PHONY: clean

--- a/macos/bt-connecter.swift
+++ b/macos/bt-connecter.swift
@@ -1,0 +1,128 @@
+import Foundation
+import IOBluetooth
+
+let programName = CommandLine.arguments.first.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "bt-connecter"
+
+func writeError(_ text: String) {
+    FileHandle.standardError.write(Data(text.utf8))
+}
+
+func usage(_ code: Int32) -> Never {
+    writeError(
+        "Usage: \(programName) [-h] <bluetooth destination> <channel>\n" +
+        "  <bluetooth destination>  device address, e.g. AA:BB:CC:DD:EE:FF\n" +
+        "  <channel>                RFCOMM channel, 1-30\n")
+    exit(code)
+}
+
+func fail(_ message: String) -> Never {
+    writeError("\(programName): \(message)\n")
+    exit(EXIT_FAILURE)
+}
+
+func normalizeAddress(_ raw: String) -> String? {
+    let parts = raw.split(whereSeparator: { $0 == ":" || $0 == "-" }).map(String.init)
+    guard parts.count == 6 else { return nil }
+    for part in parts {
+        guard part.count == 2, part.allSatisfy({ $0.isHexDigit }) else { return nil }
+    }
+    return parts.map { $0.uppercased() }.joined(separator: "-")
+}
+
+func parseChannel(_ raw: String) -> Int? {
+    guard let value = Int(raw), (1...30).contains(value) else { return nil }
+    return value
+}
+
+final class Bridge: NSObject, IOBluetoothRFCOMMChannelDelegate {
+    private var channel: IOBluetoothRFCOMMChannel?
+    private var stdinSource: DispatchSourceRead?
+    private let stdinQueue = DispatchQueue(label: "bt-connecter.stdin")
+
+    func run(address: String, channelID: Int) -> Never {
+        guard let device = IOBluetoothDevice(addressString: address) else {
+            fail("cannot resolve device \(address)")
+        }
+        var opened: IOBluetoothRFCOMMChannel?
+        let status = device.openRFCOMMChannelSync(&opened, withChannelID: BluetoothRFCOMMChannelID(channelID), delegate: self)
+        guard status == kIOReturnSuccess, let live = opened else {
+            fail("cannot open RFCOMM channel \(channelID) on \(address) (status 0x\(String(UInt32(bitPattern: status), radix: 16)))")
+        }
+        channel = live
+        let mtu = Int(live.getMTU())
+        startStdin(chunk: mtu > 0 ? mtu : 4096)
+        CFRunLoopRun()
+        exit(EXIT_SUCCESS)
+    }
+
+    private func startStdin(chunk: Int) {
+        let source = DispatchSource.makeReadSource(fileDescriptor: STDIN_FILENO, queue: stdinQueue)
+        source.setEventHandler { [weak self] in
+            guard let self = self else { return }
+            var buffer = [UInt8](repeating: 0, count: chunk)
+            let count = Darwin.read(STDIN_FILENO, &buffer, chunk)
+            if count > 0 {
+                let payload = Data(buffer[0..<count])
+                DispatchQueue.main.async { self.send(payload) }
+            } else {
+                DispatchQueue.main.async { self.finish(0) }
+            }
+        }
+        source.resume()
+        stdinSource = source
+    }
+
+    private func send(_ payload: Data) {
+        guard let live = channel else { return }
+        var mutable = payload
+        let status = mutable.withUnsafeMutableBytes { raw in
+            live.writeSync(raw.baseAddress, length: UInt16(payload.count))
+        }
+        if status != kIOReturnSuccess { finish(1) }
+    }
+
+    private func finish(_ code: Int32) -> Never {
+        channel?.close()
+        exit(code)
+    }
+
+    @objc func rfcommChannelData(_ rfcommChannel: IOBluetoothRFCOMMChannel!, data dataPointer: UnsafeMutableRawPointer!, length dataLength: Int) {
+        guard dataLength > 0 else { return }
+        let base = dataPointer.assumingMemoryBound(to: UInt8.self)
+        var offset = 0
+        while offset < dataLength {
+            let written = Darwin.write(STDOUT_FILENO, base + offset, dataLength - offset)
+            if written <= 0 { finish(1) }
+            offset += written
+        }
+    }
+
+    @objc func rfcommChannelClosed(_ rfcommChannel: IOBluetoothRFCOMMChannel!) {
+        finish(0)
+    }
+}
+
+var positional: [String] = []
+for argument in CommandLine.arguments.dropFirst() {
+    if argument == "-h" {
+        usage(EXIT_SUCCESS)
+    } else if argument.hasPrefix("-") && argument != "-" {
+        writeError("\(programName): unknown option: \(argument)\n")
+        usage(EXIT_FAILURE)
+    } else {
+        positional.append(argument)
+    }
+}
+
+guard positional.count == 2 else {
+    writeError("\(programName): need exactly two arguments: destination and channel\n")
+    usage(EXIT_FAILURE)
+}
+guard let address = normalizeAddress(positional[0]) else {
+    fail("invalid bluetooth address: \(positional[0])")
+}
+guard let channelID = parseChannel(positional[1]) else {
+    fail("invalid RFCOMM channel: \(positional[1])")
+}
+
+Bridge().run(address: address, channelID: channelID)

--- a/macos/bt-connecter.swift
+++ b/macos/bt-connecter.swift
@@ -4,7 +4,8 @@ import IOBluetooth
 let programName = CommandLine.arguments.first.map { URL(fileURLWithPath: $0).lastPathComponent } ?? "bt-connecter"
 
 func writeError(_ text: String) {
-    FileHandle.standardError.write(Data(text.utf8))
+    let bytes = Array(text.utf8)
+    _ = bytes.withUnsafeBytes { Darwin.write(STDERR_FILENO, $0.baseAddress, $0.count) }
 }
 
 func usage(_ code: Int32) -> Never {
@@ -24,7 +25,7 @@ func normalizeAddress(_ raw: String) -> String? {
     let parts = raw.split(whereSeparator: { $0 == ":" || $0 == "-" }).map(String.init)
     guard parts.count == 6 else { return nil }
     for part in parts {
-        guard part.count == 2, part.allSatisfy({ $0.isHexDigit }) else { return nil }
+        guard part.count == 2, part.allSatisfy({ $0.isHexDigit && $0.isASCII }) else { return nil }
     }
     return parts.map { $0.uppercased() }.joined(separator: "-")
 }
@@ -37,6 +38,7 @@ func parseChannel(_ raw: String) -> Int? {
 final class Bridge: NSObject, IOBluetoothRFCOMMChannelDelegate {
     private var channel: IOBluetoothRFCOMMChannel?
     private var stdinSource: DispatchSourceRead?
+    private var exitCode: Int32?
     private let stdinQueue = DispatchQueue(label: "bt-connecter.stdin")
 
     func run(address: String, channelID: Int) -> Never {
@@ -57,31 +59,41 @@ final class Bridge: NSObject, IOBluetoothRFCOMMChannelDelegate {
 
     private func startStdin(chunk: Int) {
         let source = DispatchSource.makeReadSource(fileDescriptor: STDIN_FILENO, queue: stdinQueue)
+        var buffer = [UInt8](repeating: 0, count: chunk)
         source.setEventHandler { [weak self] in
             guard let self = self else { return }
-            var buffer = [UInt8](repeating: 0, count: chunk)
-            let count = Darwin.read(STDIN_FILENO, &buffer, chunk)
+            var count = 0
+            repeat {
+                count = Darwin.read(STDIN_FILENO, &buffer, chunk)
+            } while count < 0 && errno == EINTR
             if count > 0 {
                 let payload = Data(buffer[0..<count])
-                DispatchQueue.main.async { self.send(payload) }
+                source.suspend()
+                DispatchQueue.main.async {
+                    self.send(payload)
+                    source.resume()
+                }
             } else {
-                DispatchQueue.main.async { self.finish(0) }
+                let code: Int32 = count == 0 ? 0 : 1
+                source.cancel()
+                DispatchQueue.main.async { self.finish(code) }
             }
         }
-        source.resume()
         stdinSource = source
+        source.resume()
     }
 
     private func send(_ payload: Data) {
         guard let live = channel else { return }
-        var mutable = payload
-        let status = mutable.withUnsafeMutableBytes { raw in
-            live.writeSync(raw.baseAddress, length: UInt16(payload.count))
+        let status = payload.withUnsafeBytes { raw in
+            live.writeSync(UnsafeMutableRawPointer(mutating: raw.baseAddress), length: UInt16(raw.count))
         }
         if status != kIOReturnSuccess { finish(1) }
     }
 
     private func finish(_ code: Int32) -> Never {
+        if let started = exitCode { exit(started) }
+        exitCode = code
         channel?.close()
         exit(code)
     }
@@ -92,7 +104,10 @@ final class Bridge: NSObject, IOBluetoothRFCOMMChannelDelegate {
         var offset = 0
         while offset < dataLength {
             let written = Darwin.write(STDOUT_FILENO, base + offset, dataLength - offset)
-            if written <= 0 { finish(1) }
+            if written <= 0 {
+                if written < 0 && errno == EINTR { continue }
+                finish(1)
+            }
             offset += written
         }
     }
@@ -102,10 +117,15 @@ final class Bridge: NSObject, IOBluetoothRFCOMMChannelDelegate {
     }
 }
 
+signal(SIGPIPE, SIG_IGN)
+
 var positional: [String] = []
 for argument in CommandLine.arguments.dropFirst() {
     if argument == "-h" {
         usage(EXIT_SUCCESS)
+    } else if argument == "-t" {
+        writeError("\(programName): terminal mode (-t) is not implemented\n")
+        usage(EXIT_FAILURE)
     } else if argument.hasPrefix("-") && argument != "-" {
         writeError("\(programName): unknown option: \(argument)\n")
         usage(EXIT_FAILURE)
@@ -125,4 +145,5 @@ guard let channelID = parseChannel(positional[1]) else {
     fail("invalid RFCOMM channel: \(positional[1])")
 }
 
-Bridge().run(address: address, channelID: channelID)
+let bridge = Bridge()
+bridge.run(address: address, channelID: channelID)


### PR DESCRIPTION
Adds a native macOS client (macos/, Swift + IOBluetooth) that bridges stdin/stdout to an RFCOMM channel, usable as an SSH ProxyCommand — same positional arguments as the Linux client; -t is not implemented. Built with the Xcode command line tools via macos/GNUmakefile. Tested end-to-end against bt-listener on a Raspberry Pi 5 (Debian trixie): interactive SSH incl. PTY works (terminfo must be known to the target); no SDP record is required on the server. README section update included.