### PR TITLE
bt-listener: fix fd leak and connect-failure crash, speed up the shuffler

### DIFF
--- a/src/bt-listener.cc
+++ b/src/bt-listener.cc
@@ -155,8 +155,8 @@ void connection(int sock, std::string_view remote, const std::string& target)
     if (!target.empty()) {
         ar = aw = tcp_connect(target);
         if (ar == -1) {
-            std::cerr << "Failed to connect\n";
-            exit(1);
+            std::cerr << remote << " Failed to connect to target\n";
+            return;
         }
         tcp_closer.fd = ar;
     }

--- a/src/bt-listener.cc
+++ b/src/bt-listener.cc
@@ -136,10 +136,21 @@ std::string xttyname(int fd)
     return s;
 }
 
+namespace {
+struct FdCloser {
+    int fd;
+    ~FdCloser() { if (fd >= 0) close(fd); }
+    FdCloser(const FdCloser&) = delete;
+    FdCloser& operator=(const FdCloser&) = delete;
+};
+}
+
 void connection(int sock, std::string_view remote, const std::string& target)
 {
+    FdCloser sock_closer{ sock };
     int ar = STDIN_FILENO;
     int aw = STDOUT_FILENO;
+    FdCloser tcp_closer{ -1 };
 
     if (!target.empty()) {
         ar = aw = tcp_connect(target);
@@ -147,6 +158,7 @@ void connection(int sock, std::string_view remote, const std::string& target)
             std::cerr << "Failed to connect\n";
             exit(1);
         }
+        tcp_closer.fd = ar;
     }
     Shuffler shuf;
     shuf.copy(ar, sock);

--- a/src/shuffle.cc
+++ b/src/shuffle.cc
@@ -41,7 +41,7 @@ bool set_nonblock(int fd)
 
 std::string do_read(int fd)
 {
-    constexpr size_t read_size = 128;
+    constexpr size_t read_size = 64 * 1024;
     std::vector<char> ret(read_size);
     const auto s = read(fd, ret.data(), ret.size());
     if (s < 0) {


### PR DESCRIPTION
## Summary

Three independent changes to `bt-listener` and the data shuffler:

1. `fix(bt-listener)`: close ar/sock in connection() to stop an fd leak
2. `fix(bt-listener)`: keep serving when tcp_connect() to the target fails
3. `perf(shuffle)`: read in 64 KiB chunks instead of 128 B

Verified with a Raspberry Pi 5 (Debian trixie, aarch64).

## 1. Descriptor leak in connection()

In `-t` (target) mode, `connection()` opens a TCP socket to the target
(`ar == aw`) and is handed the accepted RFCOMM socket (`sock`), then
returns without closing either. `Shuffler::run()` never closes fds, and
the accept loop drops the descriptor too, so every served session leaks
two descriptors. `handle_exec()` (the `-e` path) already closes its fds,
so only `-t` mode was affected.

Fix: wrap both descriptors in a scope-bound closer so they are released
on every exit path, including the rethrown non-connection_reset
exception.

## 2. tcp_connect() failure takes down the whole daemon

`connection()` called `exit(1)` when the target connection could not be
established, so a single failed dial (e.g. sshd briefly unavailable)
killed the entire listener. Under `Restart=always` this is masked as an
opaque outage. Changed to drop that one session and return; the accept
loop keeps running and the RFCOMM socket is closed by the guard from
change 1.

## 3. 128-byte shuffle buffer caps throughput

`do_read()` moved data in 128-byte reads. In the RFCOMM-write direction
each 128-byte chunk becomes an under-filled RFCOMM frame, holding
downstream throughput far below the radio limit.

Reading in 64 KiB chunks lets the kernel pack full RFCOMM frames.

Measured over BR/EDR (Pi 5), 3 MiB transfer, download direction:
0.32 -> 1.10 Mbit/s (3.4x). It now matches the upstream direction
(~1.05 Mbit/s), i.e. both directions are radio-bound rather than
buffer-bound.